### PR TITLE
Make config default to {}; clear up nil warning log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Snoopy Cookbook CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Default config attribute to an empty hash instead of nil so overrides can be
+  done without worrying about nil reference errors
+- Clear up a Chef nil warning by not passing on a source attribute from the
+  default recipe unless it's non-nil
 
 v1.0.0 (2015-10-22)
 -------------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,4 +19,4 @@
 #
 
 default['snoopy']['app']['source'] = nil
-default['snoopy']['config'] = nil
+default['snoopy']['config'] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,10 @@
 # limitations under the License.
 #
 
+src = node['snoopy']['app']['source']
+conf = node['snoopy']['config']
+
 snoopy 'default' do
-  source node['snoopy']['app']['source']
-  config node['snoopy']['config']
+  source src unless src.nil?
+  config conf
 end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -17,7 +17,7 @@ describe 'snoopy::default' do
     end
 
     it 'configures Snoopy with no overrides' do
-      expect(chef_run).to create_snoopy('default').with(config: nil)
+      expect(chef_run).to create_snoopy('default').with(config: {})
     end
   end
 


### PR DESCRIPTION
Defaulting the config attribute to {} instead of nil means overrides
like:

```
default['snoopy']['config']['filter_chain'] = 'only_tty:'
```

can be set instead of Chef erroring out with a nil index error.

Chef 12.5 gives a warning when passing nil to a resource from the
default recipe, but its offered solution isn't valid in Chef 11.
