### PR TITLE
Avoid `compile_time` method name collisions with old Chef Sugar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Snoopy Cookbook CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Fix issue with `compile_time` method name collisions when using the cookbook
+  in combination with older versions of Chef Sugar
 
 v1.0.1 (2015-10-22)
 -------------------

--- a/libraries/provider_snoopy_config.rb
+++ b/libraries/provider_snoopy_config.rb
@@ -46,7 +46,10 @@ class Chef
       # Render and drop off a snoopy.ini.
       #
       action :create do
-        chef_gem('inifile') { compile_time(false) if defined?(compile_time) }
+        chef_gem('inifile') do
+          Chef::Resource::ChefGem.instance_methods(false)
+            .include?(:compile_time) && compile_time(false)
+        end
         file PATH do
           content lazy {
             require 'inifile'


### PR DESCRIPTION
Prior to 3.0.1, Chef Sugar's `at_compile_time` method was called
`compile_time` and that method has a different signature, resulting in errors
in this usage of `chef_gem` when using the combination of Chef 11 + Chef Sugar
2.
