### PR TITLE
Expose an attribute that can be overridden to leave Snoopy disabled

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,13 @@ suites:
   - name: default
     run_list:
       - recipe[snoopy_test]
+  - name: disabled
+    run_list:
+      - recipe[snoopy_test]
+    attributes:
+      snoopy:
+        service:
+          enabled: false
   - name: remove
     run_list:
       - recipe[snoopy_test::remove]

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ branches:
     - master
 
 install:
-  - sudo apt-get purge -y lxc-docker
-  - wget -qO- https://get.docker.com/ | sudo sh
   - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
   - chef exec bundle install --without=development integration
 
@@ -19,9 +17,3 @@ before_script:
 
 script:
   - chef exec rake && chef exec kitchen test
-
-after_script:
-
-env:
-  global:
-    # - KITCHEN_LOCAL_YAML=.kitchen.travis.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Snoopy Cookbook CHANGELOG
 =========================
 
-v?.?.? (????-??-??)
--------------------
+Unreleased
+----------
+- Expose an attribute that can be overridden to leave Snoopy disabled
 
 v1.1.0 (2015-12-23)
 -------------------

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ group :test do
   gem 'rake'
   gem 'rubocop'
   gem 'foodcritic'
-  gem 'rspec', '>= 3'
-  gem 'chefspec', '>= 4'
+  gem 'rspec'
+  gem 'chefspec'
   gem 'simplecov'
   gem 'simplecov-console'
   gem 'coveralls'
@@ -26,8 +26,7 @@ group :test do
 end
 
 group :integration do
-  gem 'serverspec', '>= 2'
-  gem 'cucumber'
+  gem 'serverspec'
 end
 
 group :deploy do
@@ -36,6 +35,6 @@ end
 
 group :production do
   gem 'chef', '>= 11'
-  gem 'berkshelf', '>= 3'
+  gem 'berkshelf'
   gem 'inifile'
 end

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Attributes
 
 An optional custom file path or URL to a Snoopy package to install.
 
+    default['snoopy']['service']['enabled'] = true
+
+Can be overridden to leave Snoopy installed but not running.
+
     default['snoopy']['config'] = nil
 
 An optional hash of config overrides, in underscore format, to pass into

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,4 +19,5 @@
 #
 
 default['snoopy']['app']['source'] = nil
+default['snoopy']['service']['enabled'] = true
 default['snoopy']['config'] = {}

--- a/libraries/provider_snoopy.rb
+++ b/libraries/provider_snoopy.rb
@@ -49,7 +49,9 @@ class Chef
       action :create do
         snoopy_app(new_resource.name) { source new_resource.source }
         snoopy_config(new_resource.name) { config new_resource.config }
-        snoopy_service(new_resource.name)
+        snoopy_service new_resource.name do
+          action :disable unless new_resource.enabled
+        end
       end
 
       #

--- a/libraries/provider_snoopy_config.rb
+++ b/libraries/provider_snoopy_config.rb
@@ -27,7 +27,7 @@ class Chef
     #
     # @author Jonathan Hartman <jonathan.hartman@socrata.com>
     class SnoopyConfig < LWRPBase
-      PATH ||= '/etc/snoopy.ini'
+      PATH ||= '/etc/snoopy.ini'.freeze
 
       use_inline_resources
 
@@ -47,7 +47,8 @@ class Chef
       #
       action :create do
         chef_gem('inifile') do
-          Chef::Resource::ChefGem.instance_methods(false)
+          Chef::Resource::ChefGem
+            .instance_methods(false)
             .include?(:compile_time) && compile_time(false)
         end
         file PATH do

--- a/libraries/provider_snoopy_service.rb
+++ b/libraries/provider_snoopy_service.rb
@@ -76,7 +76,7 @@ class Chef
         when :remove
           libs.delete_if { |l| l == '/lib/libsnoopy.so' }.join("\n")
         else
-          fail(Chef::Exceptions::UnsupportedAction, do_action)
+          raise(Chef::Exceptions::UnsupportedAction, do_action)
         end
       end
     end

--- a/libraries/resource_snoopy.rb
+++ b/libraries/resource_snoopy.rb
@@ -36,6 +36,11 @@ class Chef
       attribute :source, kind_of: String, default: nil
 
       #
+      # Attribute to allow enabling/disabling of the Snoopy service.
+      #
+      attribute :enabled, kind_of: [TrueClass, FalseClass], default: true
+
+      #
       # Attribute to allow a set of configuration overrides.
       #
       attribute :config, kind_of: Hash, default: nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,5 @@
 # Encoding: UTF-8
-#
-# rubocop:disable SingleSpaceBeforeFirstArg
+
 name             'snoopy'
 maintainer       'Jonathan Hartman'
 maintainer_email 'jonathan.hartman@socrata.com'
@@ -15,4 +14,3 @@ supports         'ubuntu'
 supports         'redhat'
 supports         'centos'
 supports         'scientific'
-# rubocop:enable SingleSpaceBeforeFirstArg

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,9 +19,9 @@
 #
 
 src = node['snoopy']['app']['source']
-conf = node['snoopy']['config']
 
 snoopy 'default' do
   source src unless src.nil?
-  config conf
+  enabled node['snoopy']['service']['enabled']
+  config node['snoopy']['config']
 end

--- a/spec/libraries/resource_snoopy_spec.rb
+++ b/spec/libraries/resource_snoopy_spec.rb
@@ -54,6 +54,39 @@ describe Chef::Resource::Snoopy do
     end
   end
 
+  describe '#enabled' do
+    let(:enabled) { nil }
+    let(:resource) do
+      r = super()
+      r.enabled(enabled) unless enabled.nil?
+      r
+    end
+
+    context 'no override' do
+      let(:enabled) { nil }
+
+      it 'defaults to true' do
+        expect(resource.enabled).to eq(true)
+      end
+    end
+
+    context 'a valid override' do
+      let(:enabled) { false }
+
+      it 'returns the override' do
+        expect(resource.enabled).to eq(false)
+      end
+    end
+
+    context 'an invalid override' do
+      let(:enabled) { :thing }
+
+      it 'raises an error' do
+        expect { resource }.to raise_error(Chef::Exceptions::ValidationFailed)
+      end
+    end
+  end
+
   describe '#config' do
     let(:config) { nil }
     let(:resource) do

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -17,7 +17,8 @@ describe 'snoopy::default' do
     end
 
     it 'configures Snoopy with no overrides' do
-      expect(chef_run).to create_snoopy('default').with(config: {})
+      expect(chef_run).to create_snoopy('default')
+        .with(enabled: true, config: {})
     end
   end
 
@@ -35,6 +36,14 @@ describe 'snoopy::default' do
     it 'configures Snoopy with the custom config' do
       expect(chef_run).to create_snoopy('default')
         .with(config: { 'message_format' => 'test' })
+    end
+  end
+
+  context 'a custom enabled attribute' do
+    let(:overrides) { { snoopy: { service: { enabled: false } } } }
+
+    it 'configures Snoopy with the service disabled' do
+      expect(chef_run).to create_snoopy('default').with(enabled: false)
     end
   end
 end

--- a/test/fixtures/cookbooks/snoopy_test/metadata.rb
+++ b/test/fixtures/cookbooks/snoopy_test/metadata.rb
@@ -1,6 +1,5 @@
 # Encoding: UTF-8
-#
-# rubocop:disable SingleSpaceBeforeFirstArg
+
 name             'snoopy_test'
 maintainer       'Jonathan Hartman'
 maintainer_email 'jonathan.hartman@socrata.com'
@@ -12,4 +11,6 @@ version          '0.0.1'
 depends          'snoopy'
 
 supports         'ubuntu'
-# rubocop:enable SingleSpaceBeforeFirstArg
+supports         'redhat'
+supports         'centos'
+supports         'scientific'

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'serverspec'
 
-if RUBY_PLATFORM.match(/mswin|mingw32|windows/)
+if RUBY_PLATFORM =~ /mswin|mingw32|windows/
   set :os, family: 'windows'
   set :backend, :cmd
 else

--- a/test/integration/disabled/serverspec/Gemfile
+++ b/test/integration/disabled/serverspec/Gemfile
@@ -1,0 +1,5 @@
+# Encoding: UTF-8
+
+source 'https://rubygems.org'
+
+gem 'net-ssh', '~> 2.9'

--- a/test/integration/disabled/serverspec/localhost/app_spec.rb
+++ b/test/integration/disabled/serverspec/localhost/app_spec.rb
@@ -1,0 +1,15 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'snoopy::disabled::app' do
+  describe package('snoopy') do
+    it 'is installed' do
+      expect(subject).to be_installed
+    end
+
+    it 'is a recent version' do
+      expect(subject.version.version.to_i).to be > 1
+    end
+  end
+end

--- a/test/integration/disabled/serverspec/localhost/config_spec.rb
+++ b/test/integration/disabled/serverspec/localhost/config_spec.rb
@@ -1,0 +1,11 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'snoopy::disabled::config' do
+  describe file('/etc/snoopy.ini') do
+    it 'containts a Snoopy config' do
+      expect(subject.content).to match(/^\[snoopy\]$/)
+    end
+  end
+end

--- a/test/integration/disabled/serverspec/localhost/service_spec.rb
+++ b/test/integration/disabled/serverspec/localhost/service_spec.rb
@@ -1,0 +1,24 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'snoopy::disabled::service' do
+  describe file('/etc/ld.so.preload') do
+    it 'does not load the snoopy lib' do
+      expect(subject.content).to_not match(%r{^/lib/libsnoopy\.so$})
+    end
+  end
+
+  log = case os[:family]
+        when 'ubuntu', 'debian'
+          '/var/log/auth.log'
+        when 'redhat'
+          '/var/log/secure'
+        end
+  describe file(log) do
+    it 'is not logging system commands' do
+      `ls`
+      expect(subject.content).to_not match(%r{snoopy.*filename:/bin/ls})
+    end
+  end
+end

--- a/test/integration/disabled/serverspec/spec_helper.rb
+++ b/test/integration/disabled/serverspec/spec_helper.rb
@@ -1,0 +1,10 @@
+# Encoding: UTF-8
+
+require 'serverspec'
+
+if RUBY_PLATFORM.match(/mswin|mingw32|windows/)
+  set :os, family: 'windows'
+  set :backend, :cmd
+else
+  set :backend, :exec
+end

--- a/test/integration/disabled/serverspec/spec_helper.rb
+++ b/test/integration/disabled/serverspec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'serverspec'
 
-if RUBY_PLATFORM.match(/mswin|mingw32|windows/)
+if RUBY_PLATFORM =~ /mswin|mingw32|windows/
   set :os, family: 'windows'
   set :backend, :cmd
 else

--- a/test/integration/remove/serverspec/spec_helper.rb
+++ b/test/integration/remove/serverspec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'serverspec'
 
-if RUBY_PLATFORM.match(/mswin|mingw32|windows/)
+if RUBY_PLATFORM =~ /mswin|mingw32|windows/
   set :os, family: 'windows'
   set :backend, :cmd
 else


### PR DESCRIPTION
At the risk of encouraging attribute bloat, this'll provide a way for recipe users to easily disable the service.
